### PR TITLE
`clientSecret` is not required if token is for "Chrome App"

### DIFF
--- a/How to generate Google API keys.md
+++ b/How to generate Google API keys.md
@@ -6,7 +6,7 @@ Here's how to get its 2 access keys: `clientId`, `refreshToken`
 
 Version below v2 used `clientSecret`, but this is no longer used, as long as you create a "Chrome App" OAuth.
 
-*Note:* the names you enter here don't really matter. This will take approximately 10 minutes and Google likes to change these screens often. Sorry.
+*Note:* the names you enter here don't really matter. It's an app that only you will have access to. This will take approximately 10 minutes and Google likes to change these screens often. Sorry.
 
 1. Visit https://console.developers.google.com/apis/credentials
 0. Create a project:
@@ -14,8 +14,11 @@ Version below v2 used `clientSecret`, but this is no longer used, as long as you
 	<img width="772" alt="Google APIs: Create project" src="https://user-images.githubusercontent.com/1402241/77865620-9a8a3680-722f-11ea-99cb-b09e5c0c11ec.png">
 
 0. Enter `chrome-webstore-upload` and **Create**
-0. Click on **Configure consent screen**
+0. Visit https://console.cloud.google.com/apis/credentials/consent
 0. Select on **External** and **Create**
+
+	> <img width="804" alt="OAuth Consent Screen" src="https://user-images.githubusercontent.com/1402241/133878019-f159f035-2b76-4686-a461-0e0005355da6.png">
+
 0. Only enter the Application name (e.g. `chrome-webstore-upload`) and required email fields, and click **Save**
 
 	> <img width="475" alt="Consent screen configuration" src="https://user-images.githubusercontent.com/1402241/77865809-82ff7d80-7230-11ea-8a96-e381d55524c5.png">
@@ -35,17 +38,18 @@ Version below v2 used `clientSecret`, but this is no longer used, as long as you
 
 	> <img width="547" alt="Create OAuth client ID" src="https://user-images.githubusercontent.com/1402241/106205904-de6a0700-6184-11eb-8591-984e69c5e82a.png">
 
+0. Save your ✅ `clientId`; This is 1 of the 2 keys you will need
 
-0. Save your ✅ `clientId` and ignore the `clientSecret`; `clientId` is 1 of the 2 keys you will need
+	> <img width="567" alt="OAuth client created" src="https://user-images.githubusercontent.com/1402241/133878131-9303a024-3f8e-4037-9816-cdf042a91d84.png">
+
 0. Visit https://console.cloud.google.com/apis/credentials/consent
 0. Click **PUBLISH APP** and confirm
 
 	<img width="771" alt="Publish app" src="https://user-images.githubusercontent.com/27696701/114265946-2da2a280-9a26-11eb-9567-c4e00f572500.png">
 
-
 0. Place your `clientId` in this URL and open it:
 
-	`https://accounts.google.com/o/oauth2/auth?client_id=YOUR_CLIENT_ID&response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&redirect_uri=urn:ietf:wg:oauth:2.0:oob&access_type=offline&approval_prompt=force`
+	`https://accounts.google.com/o/oauth2/auth?response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchromewebstore&redirect_uri=urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob&access_type=offline&approval_prompt=force&client_id=YOUR_CLIENT_ID_HERE`
 
 0. Follow its steps and warnings (this is your own personal app)
 0. Wait on this page:

--- a/How to generate Google API keys.md
+++ b/How to generate Google API keys.md
@@ -2,7 +2,7 @@
 
 [chrome-webstore-upload](https://github.com/DrewML/chrome-webstore-upload) uses the Chrome Web Store API. 
 
-Here's how to get its 3 access keys: `clientId`, `clientSecret`, `refreshToken`
+Here's how to get its 2 access keys: `clientId`, `refreshToken`
 
 *Note:* the names you enter here don't really matter. This will take approximately 10 minutes, sorry.
 
@@ -25,14 +25,14 @@ Here's how to get its 3 access keys: `clientId`, `clientSecret`, `refreshToken`
 
 	<img width="771" alt="Create credentials" src="https://user-images.githubusercontent.com/1402241/77865679-e89f3a00-722f-11ea-942d-5245091f22b8.png">
 
-0. Select **Other** (or **Desktop app** if available), enter `chrome-webstore-upload` and click **Create** 
+0. Select **Chrome App** (or **Desktop app** if available), enter `chrome-webstore-upload` and click **Create** 
 
-	> <img width="187" alt="Configure client type" src="https://cloud.githubusercontent.com/assets/1402241/21517952/d1f36fce-cc97-11e6-92c0-de4485d97736.png">
+	> <img width="187" alt="Configure client type" src="https://user-images.githubusercontent.com/25856620/103254672-d1f16380-49b8-11eb-8cdf-98c2483be403.png">
 
-0. Save your ✅ `clientId` and ✅ `clientSecret`, these are your 2 of your 3 keys.
+0. Save your ✅ `clientId`, this is your 1 of your 2 keys.
 0. Place your `clientId` in this URL and open it:
 
-	`https://accounts.google.com/o/oauth2/auth?client_id=YOUR_CLIENT_ID&response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&redirect_uri=urn:ietf:wg:oauth:2.0:oob`
+	`https://accounts.google.com/o/oauth2/auth?client_id=YOUR_CLIENT_ID&response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&redirect_uri=urn:ietf:wg:oauth:2.0:oob&access_type=offline&approval_prompt=force`
 
 0. Follow its steps and warnings (this is your own peronal app) and wait on the last page:
 
@@ -45,7 +45,6 @@ response = await fetch('https://accounts.google.com/o/oauth2/token', {
   method: "POST",
   body: new URLSearchParams([
     ['client_id', prompt('Enter your clientId')],
-    ['client_secret', prompt('Enter your clientSecret')],
     ['code', new URLSearchParams(location.search).get('approvalCode')],
     ['grant_type', 'authorization_code'],
     ['redirect_uri', 'urn:ietf:wg:oauth:2.0:oob']
@@ -67,4 +66,4 @@ if (!json.error) {
 }
 ```
 
-9001. Done. Now you should have ✅ `clientId`, ✅ `clientSecret` and ✅ `refreshToken`. You can use these for all your extensions, but don't share them!
+9001. Done. Now you should have ✅ `clientId` and ✅ `refreshToken`. You can use these for all your extensions, but don't share them!

--- a/How to generate Google API keys.md
+++ b/How to generate Google API keys.md
@@ -29,7 +29,7 @@ Here's how to get its 2 access keys: `clientId`, `refreshToken`
 
 	> <img width="187" alt="Configure client type" src="https://user-images.githubusercontent.com/25856620/103254672-d1f16380-49b8-11eb-8cdf-98c2483be403.png">
 
-0. Save your ✅ `clientId`, this is your 1 of your 2 keys.
+0. Save your ✅ `clientId`, this is 1 of your 2 keys.
 0. Place your `clientId` in this URL and open it:
 
 	`https://accounts.google.com/o/oauth2/auth?client_id=YOUR_CLIENT_ID&response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&redirect_uri=urn:ietf:wg:oauth:2.0:oob&access_type=offline&approval_prompt=force`

--- a/How to generate Google API keys.md
+++ b/How to generate Google API keys.md
@@ -34,7 +34,8 @@ Here's how to get its 2 access keys: `clientId`, `refreshToken`
 
 	`https://accounts.google.com/o/oauth2/auth?client_id=YOUR_CLIENT_ID&response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&redirect_uri=urn:ietf:wg:oauth:2.0:oob&access_type=offline&approval_prompt=force`
 
-0. Follow its steps and warnings (this is your own personal app) and wait on the last page:
+0. Follow its steps and warnings (this is your own personal app)
+0. Wait on this page:
 
 	<img width="521" alt="Last page of OAuth" src="https://user-images.githubusercontent.com/1402241/77866731-79781480-7234-11ea-8f81-c533846d89ea.png">
 

--- a/How to generate Google API keys.md
+++ b/How to generate Google API keys.md
@@ -4,6 +4,8 @@
 
 Here's how to get its 2 access keys: `clientId`, `refreshToken`
 
+Version below v2 used `clientSecret`, but this is no longer used, as long as you create a "Chrome App" OAuth.
+
 *Note:* the names you enter here don't really matter. This will take approximately 10 minutes, sorry.
 
 1. Visit https://console.developers.google.com/apis/credentials
@@ -23,13 +25,13 @@ Here's how to get its 2 access keys: `clientId`, `refreshToken`
 0. Visit https://console.developers.google.com/apis/credentials
 0. Click **Create credentials** > **OAuth client ID**:
 
-	<img width="771" alt="Create credentials" src="https://user-images.githubusercontent.com/1402241/77865679-e89f3a00-722f-11ea-942d-5245091f22b8.png">
+	> <img width="771" alt="Create credentials" src="https://user-images.githubusercontent.com/1402241/77865679-e89f3a00-722f-11ea-942d-5245091f22b8.png">
 
-0. Select **Chrome App** (**Desktop app** and **Other** also work, if Chrome App is missing), enter `chrome-webstore-upload` and click **Create** 
+0. Select **Chrome App**, enter `Chrome Webstore Upload`, your extension’s ID, and click **Create** 
 
-	> <img width="187" alt="Configure client type" src="https://user-images.githubusercontent.com/25856620/103254672-d1f16380-49b8-11eb-8cdf-98c2483be403.png">
+	> <img width="547" alt="Create OAuth client ID" src="https://user-images.githubusercontent.com/1402241/106205904-de6a0700-6184-11eb-8591-984e69c5e82a.png">
 
-0. Save your ✅ `clientId`, this is 1 of your 2 keys.
+0. Save your ✅ `clientId` and ignore the `clientSecret`; `clientId` is 1 of 2 keys you will need.
 0. Place your `clientId` in this URL and open it:
 
 	`https://accounts.google.com/o/oauth2/auth?client_id=YOUR_CLIENT_ID&response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&redirect_uri=urn:ietf:wg:oauth:2.0:oob&access_type=offline&approval_prompt=force`

--- a/How to generate Google API keys.md
+++ b/How to generate Google API keys.md
@@ -34,7 +34,7 @@ Here's how to get its 2 access keys: `clientId`, `refreshToken`
 
 	`https://accounts.google.com/o/oauth2/auth?client_id=YOUR_CLIENT_ID&response_type=code&scope=https://www.googleapis.com/auth/chromewebstore&redirect_uri=urn:ietf:wg:oauth:2.0:oob&access_type=offline&approval_prompt=force`
 
-0. Follow its steps and warnings (this is your own peronal app) and wait on the last page:
+0. Follow its steps and warnings (this is your own personal app) and wait on the last page:
 
 	<img width="521" alt="Last page of OAuth" src="https://user-images.githubusercontent.com/1402241/77866731-79781480-7234-11ea-8f81-c533846d89ea.png">
 

--- a/How to generate Google API keys.md
+++ b/How to generate Google API keys.md
@@ -25,7 +25,7 @@ Here's how to get its 2 access keys: `clientId`, `refreshToken`
 
 	<img width="771" alt="Create credentials" src="https://user-images.githubusercontent.com/1402241/77865679-e89f3a00-722f-11ea-942d-5245091f22b8.png">
 
-0. Select **Chrome App** (or **Desktop app** if available), enter `chrome-webstore-upload` and click **Create** 
+0. Select **Chrome App** (**Desktop app** and **Other** also work, if Chrome App is missing), enter `chrome-webstore-upload` and click **Create** 
 
 	> <img width="187" alt="Configure client type" src="https://user-images.githubusercontent.com/25856620/103254672-d1f16380-49b8-11eb-8cdf-98c2483be403.png">
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install --save-dev chrome-webstore-upload
 
 ## Setup
 
-You will need a Google API `clientId`, a `clientSecret` and a `refreshToken`. Read [the guide](./How%20to%20generate%20Google%20API%20keys.md).
+You will need a Google API `clientId` and a `refreshToken`. Read [the guide](./How%20to%20generate%20Google%20API%20keys.md).
 
 ## Usage
 
@@ -24,7 +24,6 @@ All methods return an ES2015-compliant promise.
 const webStore = require('chrome-webstore-upload')({
     extensionId: 'ecnglinljpjkbgmdpeiglonddahpbkeb',
     clientId: 'xxxxxxxxxx',
-    clientSecret: 'xxxxxxxxxx',
     refreshToken: 'xxxxxxxxxx' 
 });
 ```

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ const publishURI = (id, target) => (
 const requiredFields = [
     'extensionId',
     'clientId',
-    'clientSecret',
     'refreshToken'
 ];
 
@@ -47,12 +46,11 @@ class APIClient {
     }
 
     async fetchToken() {
-        const { clientId, clientSecret, refreshToken } = this;
+        const { clientId, refreshToken } = this;
 
         const response = await got.post(refreshTokenURI, {
             json: {
                 client_id: clientId,
-                client_secret: clientSecret,
                 refresh_token: refreshToken,
                 grant_type: 'refresh_token'
             }

--- a/index.js
+++ b/index.js
@@ -51,15 +51,17 @@ class APIClient {
 
     async fetchToken() {
         const { clientId, clientSecret, refreshToken } = this;
+        const json = {
+            client_id: clientId,
+            refresh_token: refreshToken,
+            grant_type: 'refresh_token'
+        };
 
-        const response = await got.post(refreshTokenURI, {
-            json: {
-                client_id: clientId,
-                client_secret: clientSecret,
-                refresh_token: refreshToken,
-                grant_type: 'refresh_token'
-            }
-        }).json();
+        if (clientSecret) {
+            json.client_secret = clientSecret;
+        }
+
+        const response = await got.post(refreshTokenURI, {json}).json();
 
         return response.access_token;
     }

--- a/index.js
+++ b/index.js
@@ -50,11 +50,12 @@ class APIClient {
     }
 
     async fetchToken() {
-        const { clientId, refreshToken } = this;
+        const { clientId, clientSecret, refreshToken } = this;
 
         const response = await got.post(refreshTokenURI, {
             json: {
                 client_id: clientId,
+                client_secret: clientSecret,
                 refresh_token: refreshToken,
                 grant_type: 'refresh_token'
             }

--- a/test/fetchToken.js
+++ b/test/fetchToken.js
@@ -32,4 +32,4 @@ test.serial('Only returns token from response body', async t => {
     t.is(await client.fetchToken(), accessToken);
 });
 
-test.todo('Request includes clientId, clientSecret, and refreshToken');
+test.todo('Request includes clientId, and refreshToken');

--- a/test/helpers/get-client.js
+++ b/test/helpers/get-client.js
@@ -4,7 +4,6 @@ module.exports = function getClient() {
     return webStoreUpload({
         extensionId: 'foo',
         clientId: 'bar',
-        clientSecret: 'foobar',
         refreshToken: 'heyhey'
     });
 };


### PR DESCRIPTION
@fregante, as discussed I've verified that `clientSecret` is no longer needed to obtain the access token so now I'm removing that from the codebase.

The doc for generating Google API keys probably needs updating too but I think we should do that in another PR.

## What this PR does
- [x] Remove `clientSecret` (code, test and README)

Ref: [Google OAuth](https://developers.google.com/identity/protocols/oauth2#1.-obtain-oauth-2.0-credentials-from-the-dynamic_data.setvar.console_name-.)