### PR TITLE
Support deploy for partial rollout

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,10 @@ const rootURI = 'https://www.googleapis.com';
 export const refreshTokenURI = 'https://www.googleapis.com/oauth2/v4/token';
 const uploadExistingURI = id =>
     `${rootURI}/upload/chromewebstore/v1.1/items/${id}`;
-const publishURI = (id, target) =>
-    `${rootURI}/chromewebstore/v1.1/items/${id}/publish?publishTarget=${target}`;
+const publishURI = (id, target, deployPercentage) => (
+    `${rootURI}/chromewebstore/v1.1/items/${id}/publish?publishTarget=${target}`
+        + (deployPercentage == undefined ? '' : `&deployPercentage=${deployPercentage}`)
+);
 const getURI = (id, projection) =>
     `${rootURI}/chromewebstore/v1.1/items/${id}?projection=${projection}`;
 
@@ -61,10 +63,10 @@ class APIClient {
         return response;
     }
 
-    async publish(target = 'default', token = this.fetchToken()) {
+    async publish(target = 'default', token = this.fetchToken(), deployPercentage = undefined) {
         const { extensionId } = this;
 
-        const request = await fetch(publishURI(extensionId, target), {
+        const request = await fetch(publishURI(extensionId, target, deployPercentage), {
             method: 'POST',
             headers: this._headers(await token),
         });

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,8 @@ store.uploadExisting(myZipFile, token).then(res => {
 ```javascript
 const target = 'default'; // optional. Can also be 'trustedTesters'
 const token = 'xxxx'; // optional. One will be fetched if not provided
-store.publish(target, token).then(res => {
+const deployPercentage = 25; // optional. Rolls out to 100% if not provided.
+store.publish(target, token, deployPercentage).then(res => {
   // Response is documented here:
   // https://developer.chrome.com/webstore/webstore_api/items/publish
 });


### PR DESCRIPTION
Google [recently](https://groups.google.com/a/chromium.org/g/chromium-extensions/c/VOyEvRhW0FQ/m/REryZ6pDAwAJ) documented a new `deployPercentage` parameter to the `publish` API call.

This allows using [partial rollout](https://developer.chrome.com/docs/webstore/update#partial-rollout) on extensions published via the API.